### PR TITLE
fixes for #92

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -6,6 +6,7 @@
 from enum import IntEnum
 from itertools import chain
 from typing import Any
+from xml.etree import ElementTree
 
 from odxtools.utils import short_name_as_id
 from odxtools import PhysicalConstantParameter
@@ -34,6 +35,7 @@ from odxtools.functionalclass import FunctionalClass
 import odxtools.uds as uds
 from odxtools.odxtypes import DataType
 from odxtools.odxlink import OdxLinkId, OdxLinkRef, OdxDocFragment
+from odxtools.comparam_subset import ComparamSubset, read_comparam_subset_from_odx
 
 class SomersaultSID(IntEnum):
     """The Somersault-ECU specific service IDs.
@@ -56,9 +58,9 @@ dlc_short_name = "somersault"
 doc_frags = [ OdxDocFragment(dlc_short_name, "CONTAINER") ]
 
 # document fragments for communication parameters
-cp_dwcan_doc_frags = [ OdxDocFragment("ISO_11898_2_DWCAN", "COMPARAM-SPEC") ]
-cp_iso15765_2_doc_frags = [ OdxDocFragment("ISO_15765_2", "COMPARAM-SPEC") ]
-cp_iso15765_3_doc_frags = [ OdxDocFragment("ISO_15765_3", "COMPARAM-SPEC") ]
+cp_dwcan_doc_frags = [ OdxDocFragment("ISO_11898_2_DWCAN", "COMPARAM-SUBSET") ]
+cp_iso15765_2_doc_frags = [ OdxDocFragment("ISO_15765_2", "COMPARAM-SUBSET") ]
+cp_iso15765_3_doc_frags = [ OdxDocFragment("ISO_15765_3", "COMPARAM-SUBSET") ]
 
 ##################
 # Base variant of Somersault ECU
@@ -1044,7 +1046,7 @@ somersault_communication_parameters = [
 
     # a response is mandatory
     CommunicationParameterRef(
-        id_ref=OdxLinkRef("ISO_15765_3.ISO_15765_3.CP_TesterPresentReqRsp", cp_iso15765_3_doc_frags),
+        id_ref=OdxLinkRef("ISO_15765_3.CP_TesterPresentReqRsp", cp_iso15765_3_doc_frags),
         value='Response expected'),
 
     # positive response to "tester present"
@@ -1267,10 +1269,21 @@ somersault_dlc = DiagLayerContainer(
     ecu_variants=[somersault_lazy_diaglayer, somersault_assiduous_diaglayer]
 )
 
+# read the communication parameters
+comparam_subsets = []
+for odx_cs_filename in ("ISO_11898_2_DWCAN.odx-cs",
+                        "ISO_11898_3_DWFTCAN.odx-cs",
+                        "ISO_15765_2.odx-cs",
+                        "ISO_15765_3_CPSS.odx-cs"):
+    odx_cs_root = ElementTree.parse(odx_cs_filename).getroot()
+    subset = odx_cs_root.find("COMPARAM-SUBSET")
+    if subset is not None:
+        comparam_subsets.append(read_comparam_subset_from_odx(subset))
+
 # create a database object
 database = Database()
-database.diag_layer_containers = NamedItemList(short_name_as_id,
-                                               [somersault_dlc])
+database._diag_layer_containers = NamedItemList(short_name_as_id, [somersault_dlc])
+database._comparam_subsets = NamedItemList(short_name_as_id, comparam_subsets)
 
 # Create ID mapping and resolve references
 database.finalize_init()

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -114,14 +114,6 @@ class Unit:
     def __post_init__(self):
         self._physical_dimension = None
 
-        if self.factor_si_to_unit is not None or self.offset_si_to_unit is not None or self.physical_dimension_ref is not None:
-            if self.factor_si_to_unit is not None and self.offset_si_to_unit is not None and self.physical_dimension_ref is not None:
-                warnings.warn(
-                    f"Error 54: If one of factor_si_to_unit, offset_si_to_unit and physical_dimension_ref is defined,"
-                    f" all of them must be defined: {self.factor_si_to_unit} and {self.offset_si_to_unit} and {self.physical_dimension_ref}",
-                    OdxWarning
-                )
-
     @property
     def physical_dimension(self) -> PhysicalDimension:
         return self._physical_dimension


### PR DESCRIPTION
the main change is a fix for the complaints about the missing communication parameters in somersaultecu: instead of defining them from scratch, we simply read them from the .odx-cs fragments shipped with the ODX standard.

besides this, there was a wrong name in a reference to a commparam and some warning in `units.py` which stemmed from the fact that the comparam fragments shipped with the standard specify a unit with a physical dimension but without a scaling.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
